### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore files created on runtime
+custom.recipes.lua


### PR DESCRIPTION
During runtime, the mod creates a file called `custom.recipes.lua`, which is marked by Git as a change.

I am running this Git repository on my server as a submodule, and constantly having an uncommitted change is quite annoying to bear with. It would help me tremendously if the custom file is not marked as a code contribution.